### PR TITLE
webgl

### DIFF
--- a/dispatches/sizeGameCanvas.js
+++ b/dispatches/sizeGameCanvas.js
@@ -13,10 +13,9 @@ export function sizeGameCanvas() {
   //   canvas.style.removeProperty("width");
   // }
 
-  const idealWidth = canvas.width;
-  const idealHeight = canvas.height;
+  const [idealWidth, idealHeight] = window.idealDimensions || [1, 1];
   let scale = Math.min(width/idealWidth, height/idealHeight);
-  // scale = nearestPowerOf2(scale);
+  scale = nearestPowerOf2(scale);
   const w = Math.floor(idealWidth * scale);
   const h = Math.floor(idealHeight * scale);
 

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -2,6 +2,7 @@ import { bitmapTextToImageData } from "./bitmap.js";
 import { dispatch } from "../dispatch.js";
 import { textToTune } from '../textTuneConverters.js';
 import { global_state } from "../global_state.js";
+import { sizeGameCanvas } from "../dispatches/sizeGameCanvas.js";
 import * as render from "./render.js";
 
 
@@ -37,6 +38,10 @@ export function init(canvas) {
   function setScreenSize(w, h) {
     canvas.width = w;
     canvas.height = h;
+
+    window.idealDimensions = [dimensions.width, dimensions.height];
+    sizeGameCanvas();
+
     render.resize(canvas);
   }
 
@@ -224,6 +229,7 @@ export function init(canvas) {
     // check that legend keys are single characters
 
     cachedTileImages = {};
+    render.setBitmaps(bitmaps);
     dispatch("SET_BITMAPS", { bitmaps });
   }
 
@@ -275,9 +281,7 @@ export function init(canvas) {
 
     sprites = [];
 
-    const maxTileDim = ~~Math.min(canvas.width/w, canvas.height/h);
-    dimensions.maxTileDim = maxTileDim;
-    setScreenSize(w*maxTileDim, h*maxTileDim);
+    setScreenSize(w*16, h*16);
 
     for (let i = 0; i < w*h; i++) {
       const char = string.split("").filter(x => x.match(/\S/))[i];
@@ -339,7 +343,8 @@ export function init(canvas) {
   function drawTiles() {
     const grid = getGrid();
     const { width, height, maxTileDim } = dimensions;
-    const img = new ImageData(dimensions.width, dimensions.height);
+    if (width == 0 || height == 0) return new ImageData(1, 1);
+    const img = new ImageData(width, height);
 
     for (let i = 0; i < grid.length; i++) {
       const x = i%width; 
@@ -347,8 +352,9 @@ export function init(canvas) {
       const sprites = grid[i];
 
       if (!sprites[0]) continue;
+      const t = sprites[0].type;
       const r = sprites[0].type.charCodeAt(0);
-      img.data[(y*dimensions.width + x)*4 + 0] = r;
+      img.data[(y*dimensions.width + x)*4 + 0] = legend.findIndex(f => f[0] == t);
       img.data[(y*dimensions.width + x)*4 + 1] = (r*3) % 128;
       img.data[(y*dimensions.width + x)*4 + 2] = 255 - r;
       img.data[(y*dimensions.width + x)*4 + 3] = 255;

--- a/engine/engine.js
+++ b/engine/engine.js
@@ -2,6 +2,7 @@ import { bitmapTextToImageData } from "./bitmap.js";
 import { dispatch } from "../dispatch.js";
 import { textToTune } from '../textTuneConverters.js';
 import { global_state } from "../global_state.js";
+import * as render from "./render.js";
 
 
 let cur = null;
@@ -12,20 +13,13 @@ export function init(canvas) {
   canvas.parentNode.replaceChild(newCanvas, canvas);
   canvas = newCanvas;
 
-  const ctx = canvas.getContext("2d");
-
-  ctx.webkitImageSmoothingEnabled = false;
-  ctx.mozImageSmoothingEnabled = false;
-  ctx.imageSmoothingEnabled = false;
+  render.init(canvas);
 
   canvas.setAttribute("tabindex", "1");
 
 
   function gameloop() {
-    ctx.fillStyle = "white";
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    drawTiles();
+    render.render(drawTiles());
 
     animationId = window.requestAnimationFrame(gameloop);
   }
@@ -43,10 +37,7 @@ export function init(canvas) {
   function setScreenSize(w, h) {
     canvas.width = w;
     canvas.height = h;
-
-    ctx.webkitImageSmoothingEnabled = false;
-    ctx.mozImageSmoothingEnabled = false;
-    ctx.imageSmoothingEnabled = false;
+    render.resize(canvas);
   }
 
   // tile gamelab
@@ -347,31 +338,23 @@ export function init(canvas) {
 
   function drawTiles() {
     const grid = getGrid();
-    const { width, maxTileDim } = dimensions;
-    ctx.save();
-    ctx.scale(2, 2);
+    const { width, height, maxTileDim } = dimensions;
+    const img = new ImageData(dimensions.width, dimensions.height);
 
     for (let i = 0; i < grid.length; i++) {
       const x = i%width; 
       const y = Math.floor(i/width); 
       const sprites = grid[i];
 
-      if (background !== "") {
-        const c = _getTileImage(background);
-        ctx.drawImage(c, x*16, y*16);
-      }
-
-      const zOrder = legend.map(x => x[0]);
-
-      sprites
-        .sort((a, b) => zOrder.indexOf(b.type) - zOrder.indexOf(a.type))
-        .forEach( ({ type }) => {
-          const c = _getTileImage(type);
-          ctx.drawImage(c, x*16, y*16);
-        })
+      if (!sprites[0]) continue;
+      const r = sprites[0].type.charCodeAt(0);
+      img.data[(y*dimensions.width + x)*4 + 0] = r;
+      img.data[(y*dimensions.width + x)*4 + 1] = (r*3) % 128;
+      img.data[(y*dimensions.width + x)*4 + 2] = 255 - r;
+      img.data[(y*dimensions.width + x)*4 + 3] = 255;
     }
-    ctx.restore();
-   
+
+    return img;
   }
 
   function afterInput(fn) {

--- a/engine/render.js
+++ b/engine/render.js
@@ -1,4 +1,26 @@
-let gl, texLocation;
+const spritesheetIndex = 0;
+const texIndex = 1;
+let gl, texLocation, texResLocation, spritesheetLocation;
+
+export function setBitmaps(bitmaps) {
+  const sw = 16 * 4;
+  const sh = 16 * 4;
+  const spritesheet = new ImageData(sw, sh);
+  for (let i = 0; i < bitmaps.length; i++) {
+    const [_, { imageData: { data: bitmap } }] = bitmaps[i];
+    console.log(i, bitmap);
+    for (let x = 0; x < 16; x++)
+      for (let y = 0; y < 16; y++) {
+        const sx = (          (i % 4))*16 + x;
+        const sy = (Math.floor(i / 4))*16 + y;
+        spritesheet.data[(sy*sw + sx)*4 + 0] = bitmap[(y*16 + x)*4 + 0];
+        spritesheet.data[(sy*sw + sx)*4 + 1] = bitmap[(y*16 + x)*4 + 1];
+        spritesheet.data[(sy*sw + sx)*4 + 2] = bitmap[(y*16 + x)*4 + 2];
+        spritesheet.data[(sy*sw + sx)*4 + 3] = bitmap[(y*16 + x)*4 + 3];
+      }
+  }
+  uploadImage(spritesheet, spritesheetIndex);
+}
 
 export function init(canvas) {
   gl = canvas.getContext('webgl2');
@@ -6,7 +28,9 @@ export function init(canvas) {
   const program = createProgram(glsl['shader-vertex'], glsl['shader-fragment']);
   gl.useProgram(program);
 
-  texLocation = gl.getUniformLocation(program, "u_image");
+  texLocation = gl.getUniformLocation(program, "u_tex");
+  texResLocation = gl.getUniformLocation(program, "u_texres");
+  spritesheetLocation = gl.getUniformLocation(program, "u_spritesheet");
   resize(canvas);
 
   function createShader(source, type) {
@@ -40,18 +64,22 @@ export function resize(canvas) {
 }
 
 export function render(canvas) {
-  uploadImage(canvas);
+  uploadImage(canvas, texIndex, gl.NEAREST);
+
+  gl.uniform1i(spritesheetLocation, spritesheetIndex);
+  gl.uniform1i(texLocation, texIndex);
+  gl.uniform2f(texResLocation, canvas.width, canvas.height);
 
   gl.drawArrays(gl.TRIANGLE_FAN, 0, 3);
 }
 
-function uploadImage(image) {
+function uploadImage(image, i, sample=gl.NEAREST) {
   // Create a texture.
   var texture = gl.createTexture();
  
   // make unit 0 the active texture unit
   // (i.e, the unit all other texture commands will affect.)
-  gl.activeTexture(gl.TEXTURE0 + 0);
+  gl.activeTexture(gl.TEXTURE0 + i);
  
   // Bind texture to 'texture unit '0' 2D bind point
   gl.bindTexture(gl.TEXTURE_2D, texture);
@@ -60,8 +88,8 @@ function uploadImage(image) {
   // and we don't repeat
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, sample);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, sample);
  
   // Upload the image into the texture.
   var mipLevel = 0;               // the largest mip
@@ -74,22 +102,31 @@ function uploadImage(image) {
                 srcFormat,
                 srcType,
                 image);
-
-  gl.uniform1i(texLocation, 0);
 }
 
 const glsl = {
   'shader-fragment': `#version 300 es
 precision highp float;
 
-uniform sampler2D u_image;
+uniform sampler2D u_tex;
+uniform sampler2D u_spritesheet;
+uniform vec2 u_texres;
 in vec2 texCoord;
 
 out vec4 fragmentColor;
 
 void main(void) {
-  vec2 coord = vec2(texCoord.x, 1.0 - texCoord.y);
-  fragmentColor = texture(u_image, coord);
+  vec4 raw = texture(u_tex, vec2(texCoord.x, 1.0 - texCoord.y));
+  int spriteIndex = int(raw.r*255.0);
+  vec2 fcoord = mod(texCoord*u_texres, 1.0);
+  fcoord += vec2(spriteIndex%4, spriteIndex/4);
+  fragmentColor = texture(u_spritesheet, fcoord/4.0);
+  fragmentColor *= raw.a;
+  fragmentColor.a = min(fragmentColor.a, raw.a);
+  // texture(
+  //   u_spritesheet,
+  //   texCoord/4.0 + 
+  // );
 }
   `,
   'shader-vertex': `#version 300 es

--- a/engine/render.js
+++ b/engine/render.js
@@ -1,0 +1,110 @@
+let gl, texLocation;
+
+export function init(canvas) {
+  gl = canvas.getContext('webgl2');
+
+  const program = createProgram(glsl['shader-vertex'], glsl['shader-fragment']);
+  gl.useProgram(program);
+
+  texLocation = gl.getUniformLocation(program, "u_image");
+  resize(canvas);
+
+  function createShader(source, type) {
+    var shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS))
+      throw new Error(gl.getShaderInfoLog(shader));
+    return shader;
+  }
+
+  function createProgram(vertex, fragment) {
+    var program = gl.createProgram();
+    gl.attachShader(program, createShader(vertex, gl.VERTEX_SHADER));
+    gl.attachShader(program, createShader(fragment, gl.FRAGMENT_SHADER));
+    gl.linkProgram(program);
+    
+    program.createUniform = function (type, name) {
+      var location = gl.getUniformLocation(program, name);
+      return function (v1, v2, v3, v4) {
+        gl['uniform' + type](location, v1, v2, v3, v4);
+      }
+    };
+    
+    return program;
+  }
+}
+
+export function resize(canvas) {
+  gl.viewport(0, 0, canvas.width, canvas.height);
+}
+
+export function render(canvas) {
+  uploadImage(canvas);
+
+  gl.drawArrays(gl.TRIANGLE_FAN, 0, 3);
+}
+
+function uploadImage(image) {
+  // Create a texture.
+  var texture = gl.createTexture();
+ 
+  // make unit 0 the active texture unit
+  // (i.e, the unit all other texture commands will affect.)
+  gl.activeTexture(gl.TEXTURE0 + 0);
+ 
+  // Bind texture to 'texture unit '0' 2D bind point
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+ 
+  // Set the parameters so we don't need mips and so we're not filtering
+  // and we don't repeat
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+ 
+  // Upload the image into the texture.
+  var mipLevel = 0;               // the largest mip
+  var internalFormat = gl.RGBA;   // format we want in the texture
+  var srcFormat = gl.RGBA;        // format of data we are supplying
+  var srcType = gl.UNSIGNED_BYTE  // type of data we are supplying
+  gl.texImage2D(gl.TEXTURE_2D,
+                mipLevel,
+                internalFormat,
+                srcFormat,
+                srcType,
+                image);
+
+  gl.uniform1i(texLocation, 0);
+}
+
+const glsl = {
+  'shader-fragment': `#version 300 es
+precision highp float;
+
+uniform sampler2D u_image;
+in vec2 texCoord;
+
+out vec4 fragmentColor;
+
+void main(void) {
+  vec2 coord = vec2(texCoord.x, 1.0 - texCoord.y);
+  fragmentColor = texture(u_image, coord);
+}
+  `,
+  'shader-vertex': `#version 300 es
+
+precision highp float;
+
+out vec2 texCoord;
+
+void main(void) {
+    float x = float((gl_VertexID & 1) << 2);
+    float y = float((gl_VertexID & 2) << 1);
+    texCoord.x = x * 0.5;
+    texCoord.y = y * 0.5;
+    gl_Position = vec4(x - 1.0, y - 1.0, 0, 1);
+}
+  `,
+};
+


### PR DESCRIPTION
While WebGL is hardly necessary for our usecase, it was a useful tool for me as I explored what was going wrong with our rendering.

(If it is found especially onerous to maintain, I fully support going back to a canvas based solution)

The fix to the editor needed to make this renderer work is very likely to also fix our old, canvas based solutions.

The fix was twofold, and unravelled slowly. It all revolved around sizeGameCanvas.js.

First, I found that calling `setMap` with a different size wouldn't actually trigger the logic in `sizeGameCanvas`, so we would end up with canvas contents that were stretched on one axis. 

Then I found out why the games were getting progressively more pixelated with each run: `canvas.width` and `canvas.height` were being used not only to pass information between engine.js and `sizeGameCanvas.js`.

Actually, I'm still what the canvas dimensions were actually being used for in the code. `sizeGameCanvas.js` _was_ using these dimensions to derive an optimal aspect ratio, but it was also writing to this value, such that it wasn't idempotent: if you called it several times, the canvas would get smaller and smaller, though the CSS would continue scaling it to fill its container, stretching the contents in strange ways.

- okay but no big images
- actually good rendering
